### PR TITLE
devise/override: add active_for_authentication?

### DIFF
--- a/lib/devise_suspendable/model.rb
+++ b/lib/devise_suspendable/model.rb
@@ -42,7 +42,11 @@ module Devise
       def active?
         super && !suspended?
       end
-      
+
+      def active_for_authentication?
+        super && !suspended?
+      end
+
       # Overwrites invalid_message from Devise::Models::Authenticatable to define
       # the correct reason for blocking the sign in.
       def inactive_message


### PR DESCRIPTION
in commit
https://github.com/plataformatec/devise/commit/edee511cd13a1bacafb2fd9493eaa3e3c34fb160

devise renamed active? to active_for_authentication?
we override that method to prevent suspended accounts
from logging in which doesn't work after devise v1.2.0

Signed-off-by: Adam Wolk <adam.wolk@koparo.com>